### PR TITLE
fix for phpmyadmin in localhost webpage

### DIFF
--- a/core/resources/homepage/tpls/hp.index.summary.php
+++ b/core/resources/homepage/tpls/hp.index.summary.php
@@ -160,7 +160,7 @@
           </span>
           <span class="list-group-item">
             <a href="<?php echo Util::getWebsiteUrl('module/phpmyadmin', '#releases'); ?>" target="_blank" title="<?php echo $bearsamppLang->getValue(Lang::DOWNLOAD_MORE); ?>"><span style="float:right;margin-left:8px;"><i class="fa fa-download"></i></span></a>
-            <span style="float:right;font-size:12px" class="label label-primary"><?php echo $bearsamppApps->getPhpmyadmin()->getVersion() . ' (' . $bearsamppApps->getPhpmyadmin()->getVersionsStr() . ')'; ?></span>
+            <span style="float:right;font-size:12px" class="label label-primary"><?php echo $bearsamppApps->getPhpmyadmin()->getVersion(); ?></span>
             <a href="phpmyadmin" target="_blank"><?php echo $bearsamppLang->getValue(Lang::PHPMYADMIN); ?></a>
           </span>
           <span class="list-group-item">


### PR DESCRIPTION
localhost page was not building properly due to left over from phpmyadmin rewrite. in [the other pr](https://github.com/Bearsampp/Bearsampp/pull/201)

To test: 
* run ant build-lite
* go to localhost page
* verify that all of the page loads and the 3rd column shows phpmyadmin version