### PR TITLE
Sort versions properly

### DIFF
--- a/core/classes/class.util.php
+++ b/core/classes/class.util.php
@@ -265,6 +265,7 @@ class Util
         }
 
         closedir($handle);
+        natcasesort($result);
         return $result;
     }
 


### PR DESCRIPTION
To test:
your Bearsampp instance must contain php 8.1.10 to see the change.
It should look like the attached image
![image](https://user-images.githubusercontent.com/1850089/192226994-1512b5ea-a00e-4cc3-853a-d1ec2dffeca7.png)
